### PR TITLE
feat: Add XLSX export option for SQL queries

### DIFF
--- a/Classes/Manager/XlsxExportManager.php
+++ b/Classes/Manager/XlsxExportManager.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sng\Additionalscheduler\Manager;
+
+/*
+ * This file is part of the "additional_scheduler" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class XlsxExportManager extends QueryExportManager
+{
+    /**
+     * @var bool
+     */
+    protected bool $noHeader = false;
+
+    /**
+     * @param bool $noHeader
+     * @return $this
+     */
+    public function setNoHeader(bool $noHeader): self
+    {
+        $this->noHeader = $noHeader;
+        return $this;
+    }
+
+    /**
+     * Create a temporary xlsx file and return its path
+     *
+     * @param string $filename
+     * @return string - the path to the xlsx file
+     * @throws \PhpOffice\PhpSpreadsheet\Exception
+     * @throws \PhpOffice\PhpSpreadsheet\Writer\Exception
+     */
+    public function renderFile(string $filename): string
+    {
+        if (!class_exists(Spreadsheet::class)) {
+            // This check is basic. A more robust check or handling might be needed
+            // depending on how dependencies are managed in the TYPO3 extension (e.g., Composer autoloading).
+            // For now, we assume if this class is called, the library should be available.
+            // A proper dependency check will be part of a later step.
+            throw new \RuntimeException('PhpSpreadsheet library is not available. Please install it via Composer: composer require phpoffice/phpspreadsheet');
+        }
+
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+
+        $rowNumber = 1;
+        $addHeader = !$this->noHeader;
+
+        $this->parseResultSet(function ($row) use ($sheet, $addHeader, &$rowNumber): void {
+            static $first = true;
+            if ($first && $addHeader) {
+                $col = 'A';
+                foreach (array_keys($row) as $headerCell) {
+                    $sheet->setCellValue($col . $rowNumber, $headerCell);
+                    $col++;
+                }
+                $rowNumber++;
+                $first = false;
+            }
+
+            $col = 'A';
+            foreach ($row as $dataCell) {
+                $sheet->setCellValue($col . $rowNumber, $dataCell);
+                $col++;
+            }
+            $rowNumber++;
+        });
+
+        $tempDir = sys_get_temp_dir();
+        // Ensure filename ends with .xlsx
+        if (!str_ends_with($filename, '.xlsx')) {
+            $filename .= '.xlsx';
+        }
+        $tempFilePath = GeneralUtility::getFileAbsFileName($tempDir . '/' . uniqid(basename($filename, '.xlsx') . '_', true) . '.xlsx');
+
+        $writer = new Xlsx($spreadsheet);
+        $writer->save($tempFilePath);
+
+        return $tempFilePath;
+    }
+}

--- a/Classes/Manager/XlsxExportManager.php
+++ b/Classes/Manager/XlsxExportManager.php
@@ -79,9 +79,14 @@ class XlsxExportManager extends QueryExportManager
         if (empty(trim($baseFilename))) {
             $baseFilename = 'export'; // Default base if original was empty or just ".xlsx"
         }
+        // Further sanitize baseFilename to remove characters that might cause issues
+        $sanitizedBaseFilename = preg_replace('/[^a-zA-Z0-9_-]/', '', $baseFilename);
+        if (empty($sanitizedBaseFilename)) {
+            $sanitizedBaseFilename = 'export'; // Fallback if sanitization results in empty string
+        }
 
         // Ensure filename for temp file ends with .xlsx, and is unique
-        $tempFilename = uniqid($baseFilename . '_', true) . '.xlsx';
+        $tempFilename = uniqid($sanitizedBaseFilename . '_', true) . '.xlsx';
         $tempFilePath = GeneralUtility::getFileAbsFileName($tempDir . '/' . $tempFilename);
 
         if (empty($tempFilePath)) {

--- a/Classes/Tasks/Query2xlsxFields.php
+++ b/Classes/Tasks/Query2xlsxFields.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sng\Additionalscheduler\Tasks;
+
+/*
+ * This file is part of the "additional_scheduler" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+use Sng\Additionalscheduler\BaseAdditionalFieldProvider;
+use TYPO3\CMS\Scheduler\Controller\SchedulerModuleController;
+
+class Query2xlsxFields extends BaseAdditionalFieldProvider
+{
+    /**
+     * @return bool
+     */
+    public function validateAdditionalFields(array &$submittedData, SchedulerModuleController $parentObject): bool
+    {
+        $result = true;
+        if (empty($submittedData[$this->getFieldName('query')])) {
+            $this->addErrorMessage('query.error.required');
+            $result = false;
+        }
+
+        if (empty($submittedData[$this->getFieldName('filename')])) {
+            $this->addErrorMessage('filename.error.required'); // Assuming a generic error message key
+            $result = false;
+        } elseif (!str_ends_with(strtolower($submittedData[$this->getFieldName('filename')]), '.xlsx')) {
+            $submittedData[$this->getFieldName('filename')] .= '.xlsx';
+        }
+
+
+        // Basic check for PhpSpreadsheet library presence.
+        // This message will appear in the scheduler module if the class is not found.
+        if (!class_exists(\PhpOffice\PhpSpreadsheet\Spreadsheet::class)) {
+            $this->addFlashMessage(
+                'PhpSpreadsheet library not found. Please install it using Composer: "composer require phpoffice/phpspreadsheet". XLSX export will not work.',
+                'XLSX Library Missing',
+                \TYPO3\CMS\Core\Messaging\FlashMessage::WARNING // Or ::ERROR depending on desired severity
+            );
+            // Optionally, prevent saving the task or return false if it's critical
+            // For now, just a warning. The task execution will fail more clearly.
+        }
+
+
+        return $result;
+    }
+
+    /**
+     * Field structure
+     * keys are field's names, values form field data
+     *
+     * @return array
+     */
+    protected function getFields(): array
+    {
+        return [
+            'filename' => ['code' => 'input', 'default' => 'data.xlsx'],
+            'noDatetimeFlag' => ['code' => 'checkbox', 'default' => '0'],
+            'noHeader' => ['code' => 'checkbox', 'default' => '0'],
+            'query' => 'textarea',
+            'email' => 'input',
+            'subject' => 'input',
+            'body' => 'textarea',
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getTaskNs(): string
+    {
+        return 'query2xlsx';
+    }
+}

--- a/Classes/Tasks/Query2xlsxTask.php
+++ b/Classes/Tasks/Query2xlsxTask.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sng\Additionalscheduler\Tasks;
+
+/*
+ * This file is part of the "additional_scheduler" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+use Sng\Additionalscheduler\BaseEmailTask;
+use Sng\Additionalscheduler\Manager\XlsxExportManager;
+use Sng\Additionalscheduler\Utils;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class Query2xlsxTask extends BaseEmailTask
+{
+    /**
+     * @var string
+     */
+    public $query;
+
+    /**
+     * @var bool
+     */
+    public $noHeader;
+
+    /**
+     * @var string
+     */
+    public $filename;
+
+    /**
+     * @var int
+     */
+    public $noDatetimeFlag;
+
+    /**
+     * @var string
+     */
+    public $body;
+
+    /**
+     * @return bool
+     * @throws \PhpOffice\PhpSpreadsheet\Exception
+     * @throws \PhpOffice\PhpSpreadsheet\Writer\Exception
+     */
+    public function execute(): bool
+    {
+        $this->query = preg_replace('#\r\n#', ' ', $this->query);
+
+        $mailSubject = $this->subject ?: $this->getDefaultSubject('query2xlsx');
+
+        // Ensure PhpSpreadsheet is available
+        if (!class_exists(\PhpOffice\PhpSpreadsheet\Spreadsheet::class)) {
+            // Log error or notify admin, then return false or throw exception
+            // For now, simple throw, but TYPO3 logging would be better
+            throw new \RuntimeException('PhpSpreadsheet library is not available for Query2xlsxTask. Please install it via Composer.');
+        }
+
+        $path = GeneralUtility::makeInstance(XlsxExportManager::class)
+            ->setQuery($this->query)
+            ->setNoHeader((bool)$this->noHeader)
+            ->renderFile($this->filename); // XlsxExportManager handles the .xlsx extension
+
+        $finalFilename = $this->filename;
+        // Remove .xlsx if present, as it might be added by user or by default
+        if (str_ends_with(strtolower($finalFilename), '.xlsx')) {
+            $finalFilename = substr($finalFilename, 0, -5);
+        }
+
+
+        if ($this->noDatetimeFlag == 0) {
+            $finalFilename .= date('-Y-m-d_Hi');
+        }
+
+        $finalFilename .= '.xlsx'; // Ensure correct extension
+
+        if (!empty($this->email)) {
+            Utils::sendEmail($this->email, $mailSubject, $this->body, 'plain', 'utf-8', [$finalFilename => $path]);
+        }
+
+        unlink($path);
+        return true;
+    }
+}

--- a/Classes/Utils.php
+++ b/Classes/Utils.php
@@ -29,7 +29,7 @@ class Utils
      */
     public static function getTasksList(): array
     {
-        return ['Savewebsite', 'Exec', 'Execquery', 'Clearcache', 'Cleart3temp', 'Query2csv'];
+        return ['Savewebsite', 'Exec', 'Execquery', 'Clearcache', 'Cleart3temp', 'Query2csv', 'Query2xlsx'];
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This extension add new process in your scheduler module, for example you can :
 * exec a SH script (with mail report)
 * exec a SQL query with data put into a HTML table in an email
 * exec a SQL query with CSV as mail attachment (with options for separator, escaping, etc.) 
+* exec a SQL query with XLSX as mail attachment (requires phpoffice/phpspreadsheet library)
 * clear caches
 * clear files in typo3temp older than x days
 
@@ -57,6 +58,28 @@ This extension work with TYPO3 11.5.x-13.4.x.
 #### Mail
 
 ![](https://raw.githubusercontent.com/Apen/additional_scheduler/master/Resources/Public/Images/query-email.png)
+
+### exec a SQL query with XLSX as mail attachment
+
+This task allows you to execute a SQL query and receive the results as an XLSX file attached to an email.
+
+**Prerequisites:**
+This feature requires the `phpoffice/phpspreadsheet` library. If you haven't installed it yet, you can add it to your TYPO3 project using Composer:
+```bash
+composer require phpoffice/phpspreadsheet
+```
+
+**Configuration Options:**
+
+*   **Filename:** The desired name for the XLSX file (e.g., `export_data.xlsx`).
+*   **No Datetime Suffix:** If checked, the current date and time will not be appended to the filename.
+*   **No Header Row:** If checked, the first row of the XLSX file will not contain the column names (headers).
+*   **SQL Query:** The SQL query to execute.
+*   **Email:** The recipient email address.
+*   **Subject:** The subject of the email.
+*   **Body:** The body content of the email.
+
+**(TODO: Add a screenshot of the configuration for Query2xlsxTask once available/created)**
 
 ### clear files in typo3temp older than x days
 

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -29,7 +29,7 @@
 				<source><![CDATA[Don't add date-time at the end of the filename]]></source>
 			</trans-unit>
 			<trans-unit id="noHeader">
-				<source><![CDATA[Don't add field names as the first line of the CSV]]></source>
+				<source><![CDATA[Don't add field names as the first row of the export file (CSV/XLSX)]]></source>
 			</trans-unit>
             <trans-unit id="delimiter">
                 <source><![CDATA[Delimiter for csv file]]></source>
@@ -73,6 +73,9 @@
 			<trans-unit id="query.error.required">
 				<source><![CDATA[SQL query is mandatory]]></source>
 			</trans-unit>
+            <trans-unit id="filename.error.required">
+                <source><![CDATA[Filename is mandatory.]]></source>
+            </trans-unit>
 			<trans-unit id="savedir">
 				<source><![CDATA[Full path of the save directory (/aaa/bbb/ccc/)]]></source>
 			</trans-unit>
@@ -103,6 +106,12 @@
 			<trans-unit id="task.query2csv.name">
 				<source><![CDATA[Send a CSV]]></source>
 			</trans-unit>
+            <trans-unit id="task.query2xlsx.name">
+                <source><![CDATA[Query to XLSX (Email Attachment)]]></source>
+            </trans-unit>
+            <trans-unit id="task.query2xlsx.description">
+                <source><![CDATA[Executes a SQL query and sends the results as an XLSX file attached to an email. Requires phpoffice/phpspreadsheet library.]]></source>
+            </trans-unit>
 			<trans-unit id="task.savewebsite.description">
 				<source><![CDATA[Full backup with DB + files]]></source>
 			</trans-unit>

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
     "symplify/easy-coding-standard": "^11",
     "helmich/typo3-typoscript-lint": "^3"
   },
+  "suggests": {
+    "phpoffice/phpspreadsheet": "Required for XLSX export functionality. Install with 'composer require phpoffice/phpspreadsheet'"
+  },
   "autoload": {
     "psr-4": {
       "Sng\\Additionalscheduler\\": "Classes"


### PR DESCRIPTION
(Sorry for the 3 older commits by Jules, I was not expecting that)

Adds a new scheduler task to execute an SQL query and export the results as an XLSX file attached to an email.

Features:
- New XlsxExportManager for generating XLSX files using PhpSpreadsheet.
- New Query2xlsxTask and Query2xlsxFields for scheduler integration.
- Option to include/exclude headers and timestamp in filename.
- Dependency on phpoffice/phpspreadsheet is handled via composer.json suggestions and runtime checks.
- Documentation and localization updated.